### PR TITLE
이미지 삽입 URL 형식을 상대 주소로 변경

### DIFF
--- a/assets/js/media_library.widget.js
+++ b/assets/js/media_library.widget.js
@@ -187,7 +187,7 @@ window.$(function ($) {
     _normalizeFileData: function (payload) {
       var data = {
         title: payload.title || payload.clientname,
-        imageUrl: XE._.get(payload, 'file.url', payload.url),
+        imageUrl: new URL(XE._.get(payload, 'file.url', payload.url)).pathname,
         mediaId: (payload.file_id) ? XE._.get(payload, 'id', '') : '',
         fileId: XE._.get(payload, 'file_id', payload.id || ''),
         size: payload.size,


### PR DESCRIPTION
![Peek 2020-03-21 02-08](https://user-images.githubusercontent.com/24864600/77188168-f01c6000-6b18-11ea-9288-96a1e96b00bd.gif)

`media.import` 이벤트를 호출하는 부분이 한 곳뿐이라 `media_library.widget.js`의 `_normalizeFileData`에서 이미지를 상대 주소로 리턴하게 고쳐봤습니다.
혹 사이드 이펙트가 발생하지는 않는지 테스트를 해봐야 할 것 같습니다. 

resolve #69 